### PR TITLE
monad-bayes series Nix environment: update jupyterWith pin

### DIFF
--- a/monad-bayes-series/haskell-overlay.nix
+++ b/monad-bayes-series/haskell-overlay.nix
@@ -4,15 +4,15 @@ let
   ihaskellSrc = pkgs.fetchFromGitHub {
     owner = "gibiansky";
     repo = "IHaskell";
-    rev = "2318ee2a90cfc98390651657aec434586b963235";
-    sha256 = "0svjzs81i77s710cfb7pxkfdi979mhjazpc2l9k9ha752spz04cj";
+    rev = "a992ad83702e55b774de234d77ffd2682d842682";
+    sha256 = "123kbmkpbh978x9c30igxz2xlr9842lddfgnkxbidwzscbccqrh8";
   };
 
   monadBayesSrc = pkgs.fetchFromGitHub {
-    owner = "adscib";
+    owner = "tweag";
     repo = "monad-bayes";
-    rev = "fb87bf039bab35dcc82de8ccf8963a7a576af355";
-    sha256 = "0jz7lswdzxzn5zzwypdawdj7j0y20aakmqggv9pw4sknajdqqqyf";
+    rev = "1d368b9309b39112a7b38e779157ae481dd1c2ef";
+    sha256 = "15sf3gm2zn31wcxbr8yqvnsfgnw176xn79vfqcf536bscx2l6bvp";
   };
 
   hVegaSrc = pkgs.fetchFromGitHub {

--- a/monad-bayes-series/haskell-overlay.nix
+++ b/monad-bayes-series/haskell-overlay.nix
@@ -1,11 +1,14 @@
+# Mostly copied from:
+# https://raw.githubusercontent.com/tweag/jupyterWith/b0b4e55da09973a57b82200789816f050a970f3e/nix/haskell-overlay.nix
+
 _: pkgs:
 
 let
   ihaskellSrc = pkgs.fetchFromGitHub {
     owner = "gibiansky";
     repo = "IHaskell";
-    rev = "a992ad83702e55b774de234d77ffd2682d842682";
-    sha256 = "123kbmkpbh978x9c30igxz2xlr9842lddfgnkxbidwzscbccqrh8";
+    rev = "d7dc460a421abaa41e04fe150e264bc2bab5cbad";
+    sha256 = "157mqfprjbjal5mvrqwpgnfvc93fn1pqwwkhfpcs7jm5c34bkv3q";
   };
 
   monadBayesSrc = pkgs.fetchFromGitHub {
@@ -67,36 +70,21 @@ let
       ihaskell-widgets = callDisplayPackage "widgets";
 
       # Marked as broken in this version of Nixpkgs.
-      chell = hspkgs.callHackage "chell" "0.4.0.2" {};
-      patience = hspkgs.callHackage "patience" "0.1.1" {};
-
-      # Version compatible with ghc-lib-parser.
-      hlint = hspkgs.callHackage "hlint" "2.2.1" {};
+      #chell = hspkgs.callHackage "chell" "0.4.0.2" {};
+      #patience = hspkgs.callHackage "patience" "0.1.1" {};
 
       # Tests not passing.
-      Diff = dontCheck hspkgs.Diff;
-      zeromq4-haskell = dontCheck hspkgs.zeromq4-haskell;
-      funflow = dontCheck hspkgs.funflow;
-
-      # Haddocks not building.
-      ghc-lib-parser = dontHaddock hspkgs.ghc-lib-parser;
-
-      # Missing dependency.
-      aeson = pkgs.haskell.lib.addBuildDepends hspkgs.aeson [ self.contravariant ];
-
+      #Diff = dontCheck hspkgs.Diff;
+      #zeromq4-haskell = dontCheck hspkgs.zeromq4-haskell;
 
     };
 in
 
 {
-  haskell = pkgs.haskell // {
-    packages = pkgs.haskell.packages // {
-      "ghc865" = pkgs.haskell.packages.ghc865.override (old: {
-          overrides =
-              pkgs.lib.composeExtensions
-                (old.overrides or (_: _: {}))
-                overrides;}
-              );
-            };
-          };
+  haskellPackages = pkgs.haskellPackages.override (old: {
+    overrides =
+      pkgs.lib.composeExtensions
+        (old.overrides or (_: _: {}))
+        overrides;
+  });
 }

--- a/monad-bayes-series/shell.nix
+++ b/monad-bayes-series/shell.nix
@@ -1,7 +1,7 @@
 let
   jupyterLib = builtins.fetchGit {
     url = https://github.com/tweag/jupyterWith;
-    rev = "70f1dddd6446ab0155a5b0ff659153b397419a2d";
+    rev = "b0b4e55da09973a57b82200789816f050a970f3e";
   };
   nixpkgsPath = jupyterLib + "/nix";
   haskellOverlay = import ./haskell-overlay.nix;

--- a/monad-bayes-series/shell.nix
+++ b/monad-bayes-series/shell.nix
@@ -29,11 +29,15 @@ let
   jupyterlabWithKernels =
     jupyter.jupyterlabWith {
       kernels = [ ihaskellWithPackages ];
-      directory = jupyter.mkDirectoryWith {
-        extensions = [
-          "jupyterlab-ihaskell"
-        ];
-      };
+      # The jupyterlab-ihaskell extension is incompatible with the latest
+      # jupyterWith version. Re-enable the extension to get syntax highlighting
+      # once there is a compatible version.
+      #
+      #directory = jupyter.mkDirectoryWith {
+      #  extensions = [
+      #    "jupyterlab-ihaskell"
+      #  ];
+      #};
     };
 in
   jupyterlabWithKernels.env


### PR DESCRIPTION
This PR updates the pinned revision of `jupyterWith`.

`jupyterWith` has macOS CI set up now. The revision this PR updates the pin to has passed macOS CI: https://github.com/tweag/jupyterWith/runs/733371600.

Should fix https://github.com/tweag/blog-resources/issues/12, though I haven't been able to test this myself.