### PR TITLE
Add the Cabal package for ill-formedess-indicators

### DIFF
--- a/ill-formedness-indicators/variadic-mkvec/README.md
+++ b/ill-formedness-indicators/variadic-mkvec/README.md
@@ -1,0 +1,15 @@
+This package is a demonstration of the Ill-Formedness Indicators technique, derived from Csongor Kiss's blog post [_Detecting the undetectable: custom type errors for stuck type families_](https://blog.csongor.co.uk/report-stuck-families/).
+
+For the most part, the files in this repository are meant to be read, since it's a demonstration.
+Read the Haskell modules and also read `test/expected-warnings.txt`; nothing else is particularly interesting.
+
+If you're cautious, run the tests at the `bash` prompt with the command `test/check` in order to confirm the contents of `test/expected-warnings.txt`
+This approach is unfortunately fragile; in particular, if you have a different version of GHC, the test will fail.
+But you can probably still come away with the right idea by reading `test/expected-warnings.txt`.
+The provided `shell.nix` is how I was testing it.
+
+The `Enclosed*` modules define the combinators using one kind of intended sytnax.
+The `Sentinel*` modules use a different syntax, but moreover require `-XIncoherentInstances` in order to get the same degree of expressivity.
+That's the only difference.
+
+The `EnclosedOI` module uses `-XOverlappingInstances` to get some of the benefits of Ill-Formedness Indicators (good errors in closed contexts), but not all (no error and a bad inferred signature in open contexts).

--- a/ill-formedness-indicators/variadic-mkvec/cabal.project
+++ b/ill-formedness-indicators/variadic-mkvec/cabal.project
@@ -1,0 +1,1 @@
+packages: .

--- a/ill-formedness-indicators/variadic-mkvec/shell.nix
+++ b/ill-formedness-indicators/variadic-mkvec/shell.nix
@@ -1,0 +1,12 @@
+{ pkgs ? import (builtins.fetchTarball "https://nixos.org/channels/nixos-22.11/nixexprs.tar.xz") {}
+}:
+
+with pkgs;
+
+mkShell rec {
+  name = "variadic-mkvec-env";
+
+  ghc = haskell.compiler.ghc8107;
+
+  buildInputs = [ bash cabal-install ghc ];
+}

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec.hs
@@ -1,0 +1,45 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GADTs #-}
+{-# LANGUAGE KindSignatures #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module Data.Vec (
+    Vec (VCons, VNil),
+    Rev (rev),
+  ) where
+
+import           Data.Kind (Type)
+
+-----
+
+-- | A bog standard Haskell heterogenous vector data type.
+data Vec :: [Type] -> Type where
+    VNil  ::                Vec '[]
+    VCons :: x -> Vec xs -> Vec (x : xs)
+
+instance Show (Vec '[]) where show VNil = "VNil"
+
+instance (Show x, Show (Vec xs)) => Show (Vec (x : xs)) where
+    showsPrec p (VCons x xs) =
+          showParen (p > 10)
+        $ showString "VCons " . showsPrec 11 x . showChar ' ' . showsPrec 11 xs
+
+-----
+
+-- | I don't use a @Reversed@ type family for the sake of simplicity.
+--
+-- Somewhat surprisingly, I also don't use a functional dependency. I suspect
+-- the fact that this class is only used by 'MkLitVec', which has an
+-- Ill-Formedness Indicator, means that a fundep would never be useful, since
+-- the type indices will necesssarily be concrete.
+class Rev acc xs acc' where rev :: Vec acc -> Vec xs -> Vec acc'
+
+instance (acc' ~ acc) => Rev acc '[] acc' where
+    rev acc = \VNil -> acc
+
+instance Rev (x : acc) xs acc' => Rev acc (x : xs) acc' where
+    rev acc = \(VCons x xs) -> rev (VCons x acc) xs

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/Enclosed.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/Enclosed.hs
@@ -1,0 +1,55 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | See 'litVec'.
+module Data.Vec.LiteralSyntax.Enclosed (
+    litVec,
+    variadic,
+  ) where
+
+import           Data.Proxy (Proxy (Proxy))
+import           Data.Vec
+import           Data.Void (Void)
+import           GHC.TypeLits (ErrorMessage (Text), TypeError)
+
+-----
+
+class MkLitVec (ifi :: Void) xs a where mkLitVec :: Proxy ifi -> Vec xs -> a
+
+instance (MkLitVec ifi (x : xs) a) => MkLitVec ifi xs (x -> a) where
+    mkLitVec ifi acc = \x -> mkLitVec ifi (VCons x acc)
+
+newtype Variadic a = MkVariadic { {- | See 'litVec' -} variadic :: a }
+
+instance (a ~ Vec xs', Rev '[] xs xs') => MkLitVec ifi xs (Variadic a) where
+    mkLitVec _ifi acc = MkVariadic (rev VNil acc)
+
+-----
+
+-- | An alias of 'TypeError'
+--
+-- This family avoids a compile-time error in the /definition/ of 'beginVec'.
+-- That is its only use. <https://gitlab.haskell.org/ghc/ghc/-/issues/20241>
+-- should happily supplant this in future GHCs.
+type family DelayTypeError (msg :: ErrorMessage) :: Void where
+    DelayTypeError msg = TypeError msg
+
+-- | This could include more details of the user's error, by taking type
+-- parameters and including them in the message via 'GHC.TypeLits.ShowType'.
+type LitVecErrMsg = Text "Likely accidental use of `litVec' outside of `variadic'!"
+
+-- | A variadic vector constructor
+--
+-- Template: @'variadic' ('litVec' ...)@
+--
+-- Any use of 'litVec' outside of the 'variadic' syntactic context---even in a
+-- closed-world context!---will cause a compile-time error. A determined user
+-- could subvert that compile-time error, but we don't expect any user to
+-- desire that or do so accidentally.
+litVec :: MkLitVec (DelayTypeError LitVecErrMsg) '[] a => a
+litVec = mkLitVec (Proxy :: Proxy (DelayTypeError LitVecErrMsg)) VNil

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/EnclosedOI.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/EnclosedOI.hs
@@ -1,0 +1,44 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | See 'litVec'.
+module Data.Vec.LiteralSyntax.EnclosedOI (
+    litVec,
+    variadic,
+  ) where
+
+import           Data.Vec
+import           GHC.TypeLits (ErrorMessage (Text), TypeError)
+
+-----
+
+class MkLitVec xs a where mkLitVec :: Vec xs -> a
+
+instance {-# OVERLAPS #-} (MkLitVec (x : xs) a) => MkLitVec xs (x -> a) where
+    mkLitVec acc = \x -> mkLitVec (VCons x acc)
+
+newtype Variadic a = MkVariadic { {- | See 'litVec' -} variadic :: a }
+
+instance {-# OVERLAPS #-} (a ~ Vec xs', Rev '[] xs xs') => MkLitVec xs (Variadic a) where
+    mkLitVec acc = MkVariadic (rev VNil acc)
+
+type LitVecErrMsg = Text "Likely accidental use of `litVec' outside of `variadic'!"
+instance TypeError LitVecErrMsg => MkLitVec xs a where mkLitVec = error "unreachable"
+
+-----
+
+-- | A variadic vector constructor
+--
+-- Template: @'variadic' ('litVec' ...)@
+--
+-- If you forget to apply 'variadic' in an open-world context (eg in a
+-- definition with no signature), the inferred type will include an inscrutable
+-- context laden with implementation details. "Data.Vec.LiteralSyntax.Enclosed"
+-- improves that UX by careful use of 'GHC.TypeLits.TypeError'.
+litVec :: MkLitVec '[] a => a
+litVec = mkLitVec VNil

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/EnclosedUnguarded.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/EnclosedUnguarded.hs
@@ -1,0 +1,43 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | See 'litVec'.
+module Data.Vec.LiteralSyntax.EnclosedUnguarded (
+    litVec,
+    variadic,
+  ) where
+
+import           Data.Vec
+
+-----
+
+class MkLitVec xs a where mkLitVec :: Vec xs -> a
+
+instance (MkLitVec (x : xs) a) => MkLitVec xs (x -> a) where
+    mkLitVec acc = \x -> mkLitVec (VCons x acc)
+
+newtype Variadic a = MkVariadic { {- | See 'litVec' -} variadic :: a }
+
+instance (a ~ Vec xs', Rev '[] xs xs') => MkLitVec xs (Variadic a) where
+    mkLitVec acc = MkVariadic (rev VNil acc)
+
+-----
+
+-- | A variadic vector constructor
+--
+-- Template: @'variadic' ('litVec' ...)@
+--
+-- If you forget to apply 'variadic', the inferred type and/or error messages
+-- will include an inscrutable context laden with implementation details.
+-- "Data.Vec.LiteralSyntax.Enclosed" improves that UX by a careful use of
+-- 'GHC.TypeLits.TypeError' called an Ill-Formedness Indicator.
+-- "Data.Vec.LiteralSyntax.EnclosedOI" only partially acheives that
+-- improvement, using `-XOverlappingInstances` instead of Ill-Formedness
+-- Indicators.
+litVec :: MkLitVec '[] a => a
+litVec = mkLitVec VNil

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/Sentinel.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/Sentinel.hs
@@ -1,0 +1,67 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | See 'beginVec'.
+module Data.Vec.LiteralSyntax.Sentinel (
+    beginVec,
+    endVec,
+  ) where
+
+import           Data.Proxy (Proxy (Proxy))
+import           Data.Vec
+import           Data.Void (Void)
+import           GHC.TypeLits (ErrorMessage (Text), TypeError)
+
+-----
+
+class MkBeginVec (ifi :: Void) xs a where mkBeginVec :: Proxy ifi -> Vec xs -> a
+
+instance (MkBeginVec ifi (x : xs) a) => MkBeginVec ifi xs (x -> a) where
+    mkBeginVec ifi acc = \x -> mkBeginVec ifi (VCons x acc)
+
+data Sentinel = Sentinel
+
+-- | Incoherent so that GHC will select the other 'MkBeginVec' instance even when
+-- the function domain is a type variable (despite the possibility that it
+-- could later unify with 'Sentinel'). Such greedy instance selection is
+-- acceptable, even desirable, in this case, since we intend for 'beginVec' and
+-- 'endVec' to be treated as a /syntactic/ begin-end pair, never incrementally
+-- assembled via combinators, never abstracted over, etc.
+--
+-- The syntactic intention is enforced by the Ill-Formedness Indicator.
+instance {-# INCOHERENT #-} (a ~ Vec xs', Rev '[] xs xs') => MkBeginVec ifi xs (Sentinel -> a) where
+    mkBeginVec _ifi acc = \Sentinel -> rev VNil acc
+
+-----
+
+-- | An alias of 'TypeError'
+--
+-- This family avoids a compile-time error in the /definition/ of 'beginVec'.
+-- That is its only use. <https://gitlab.haskell.org/ghc/ghc/-/issues/20241>
+-- should happily supplant this in future GHCs.
+type family DelayTypeError (msg :: ErrorMessage) :: Void where
+    DelayTypeError msg = TypeError msg
+
+-- | This could include more details of the user's error, by taking type
+-- parameters and including them in the message via 'GHC.TypeLits.ShowType'.
+type LitVecErrMsg = Text "Likely accidental use of `beginVec' without `endVec'!"
+
+-- | A variadic vector constructor
+--
+-- Template: @'beginVec' ... 'endVec'@
+--
+-- Any use of 'beginVec' that is not applied to 'endVec'---even in a
+-- closed-world context!---will cause a compile-time error. A determined user
+-- could subvert that compile-time error, but we don't expect any user to
+-- desire that or do so accidentally.
+beginVec :: MkBeginVec (DelayTypeError LitVecErrMsg) '[] a => a
+beginVec = mkBeginVec (Proxy :: Proxy (DelayTypeError LitVecErrMsg)) VNil
+
+-- | See 'beginVec'.
+endVec :: Sentinel
+endVec = Sentinel

--- a/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/SentinelUnguarded.hs
+++ b/ill-formedness-indicators/variadic-mkvec/src/Data/Vec/LiteralSyntax/SentinelUnguarded.hs
@@ -1,0 +1,56 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
+{-# LANGUAGE TypeFamilies #-}
+{-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+-- | See 'beginVec'.
+module Data.Vec.LiteralSyntax.SentinelUnguarded (
+    endVec,
+    beginVec,
+  ) where
+
+import           Data.Vec
+
+-----
+
+class MkBeginVec xs a where mkBeginVec :: Vec xs -> a
+
+instance (MkBeginVec (x : xs) a) => MkBeginVec xs (x -> a) where
+    mkBeginVec acc = \x -> mkBeginVec (VCons x acc)
+
+data Sentinel = Sentinel
+
+-- | Incoherent so that GHC will select the other 'MkBeginVec' instance even when
+-- the function domain is a type variable (despite the possibility that it
+-- could later unify with 'Sentinel'). Such greedy instance selection is
+-- acceptable, even desirable, in this case, since we intend for 'beginVec' and
+-- 'endVec' to be treated as a /syntactic/ begin-end pair, never incrementally
+-- assembled via combinators, never abstracted over, etc.
+--
+-- The syntactic intention would be enforced by an Ill-Formedness Indicator,
+-- like the one added in "Data.Vec.LiteralSyntax.Sentinel".
+--
+-- "Data.Vec.LiteralSyntax.EnclosedUnguarded" avoids the need for this
+-- incoherency, by using a slightly different shape of syntactic pair.
+instance {-# INCOHERENT #-} (a ~ Vec xs', Rev '[] xs xs') => MkBeginVec xs (Sentinel -> a) where
+    mkBeginVec acc = \Sentinel -> rev VNil acc
+
+-----
+
+-- | A variadic vector constructor
+--
+-- Template: @'beginVec' ... 'endVec'@
+--
+-- If you forget to supply 'endVec', the inferred type and/or error messages
+-- will include an inscrutable context laden with implementation details.
+-- That's the motivation of adding an Ill-Formedness Indicator in
+-- "Data.Vec.LiteralSyntax.Sentinel".
+beginVec :: MkBeginVec '[] a => a
+beginVec = mkBeginVec VNil
+
+-- | See 'beginVec'.
+endVec :: Sentinel
+endVec = Sentinel

--- a/ill-formedness-indicators/variadic-mkvec/test/EmitWarnings.hs
+++ b/ill-formedness-indicators/variadic-mkvec/test/EmitWarnings.hs
@@ -1,0 +1,9 @@
+module Main (main) where
+
+import qualified Test1 ()
+import qualified Test2 ()
+
+import           System.Exit (die)
+
+main :: IO ()
+main = die "This test always fails; the only point of it is that building it causes 'Test1' and 'Test2' to generate warnings, which are to be checked by other scripts."

--- a/ill-formedness-indicators/variadic-mkvec/test/Test1.hs
+++ b/ill-formedness-indicators/variadic-mkvec/test/Test1.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE FlexibleContexts #-}
+
+{-# OPTIONS_GHC -Wmissing-signatures #-}
+
+module Test1 (module Test1) where
+
+import qualified Data.Vec.LiteralSyntax.Enclosed as X
+import qualified Data.Vec.LiteralSyntax.EnclosedOI as XOI
+import qualified Data.Vec.LiteralSyntax.EnclosedUnguarded as XU
+import qualified Data.Vec.LiteralSyntax.Sentinel as Y
+import qualified Data.Vec.LiteralSyntax.SentinelUnguarded as YU
+
+-----
+
+-- All of the definitions have the perfect inferred signature when the syntax
+-- is used as intended.
+
+enclosedGoodInferredSignature  a b c = X.variadic (X.litVec a b c)
+enclosedGoodInferredSignature1 a b c = XOI.variadic (XU.litVec a b c)
+enclosedGoodInferredSignature2 a b c = XU.variadic (XU.litVec a b c)
+
+sentinelGoodInferredSignature  a b c = Y.beginVec a b c Y.endVec 
+sentinelGoodInferredSignature' a b c = YU.beginVec a b c YU.endVec 
+
+-----
+
+-- In the open-world context, we get a bad inferred signature from the syntax
+-- mistake instead of a good error message because these definitions did not
+-- use Ill-Formedness Indicators.
+
+enclosedBadInferredSignature  a b c = XU.litVec a b c
+enclosedBadInferredSignature' a b c = XOI.litVec a b c
+
+sentinelBadInferredSignature a b c = YU.beginVec a b c

--- a/ill-formedness-indicators/variadic-mkvec/test/Test2.hs
+++ b/ill-formedness-indicators/variadic-mkvec/test/Test2.hs
@@ -1,0 +1,35 @@
+{-# LANGUAGE DataKinds #-}
+
+{-# OPTIONS_GHC -fdefer-type-errors #-}
+
+module Test2 (module Test2) where
+
+import           Data.Vec (Vec)
+import qualified Data.Vec.LiteralSyntax.Enclosed as X
+import qualified Data.Vec.LiteralSyntax.EnclosedOI as XOI
+import qualified Data.Vec.LiteralSyntax.EnclosedUnguarded as XU
+import qualified Data.Vec.LiteralSyntax.Sentinel as Y
+import qualified Data.Vec.LiteralSyntax.SentinelUnguarded as YU
+
+-----
+
+-- The Ill-Formedness Indicators and the overlapping instance both give good
+-- error messages when a signature is provided but the syntax mistake was made.
+
+enclosedGoodErrorMessage  :: a -> b -> c -> Vec [a, b, c]
+enclosedGoodErrorMessage' :: a -> b -> c -> Vec [a, b, c]
+enclosedGoodErrorMessage  a b c = X.litVec a b c
+enclosedGoodErrorMessage' a b c = XOI.litVec a b c
+
+sentinelGoodErrorMessage :: a -> b -> c -> Vec [a, b, c]
+sentinelGoodErrorMessage a b c = Y.beginVec a b c
+
+-----
+
+-- The minimal definitions instead give bad error messages.
+
+enclosedBadErrorMessage :: a -> b -> c -> Vec [a, b, c]
+enclosedBadErrorMessage a b c = XU.litVec a b c
+
+sentinelBadErrorMessage :: a -> b -> c -> Vec [a, b, c]
+sentinelBadErrorMessage a b c = YU.beginVec a b c

--- a/ill-formedness-indicators/variadic-mkvec/test/accept
+++ b/ill-formedness-indicators/variadic-mkvec/test/accept
@@ -1,0 +1,7 @@
+#/bin/bash
+
+# Update expected-warnings.txt to contain those emited by emit-warnings.
+
+cabal build emit-warnings || { echo 'library build failed'; exit 1; }
+echo | GHC_NO_UNICODE="TRUE" cabal repl emit-warnings 1>"$(dirname $0)/expected-warnings.txt" 2>&1 || { echo 'accept failed'; exit 2; }
+1>&2 echo 'accept passed'

--- a/ill-formedness-indicators/variadic-mkvec/test/check
+++ b/ill-formedness-indicators/variadic-mkvec/test/check
@@ -1,0 +1,7 @@
+#/bin/bash
+
+# Check the warnings emitted by emit-warnings against expected-warnings.txt.
+
+cabal build emit-warnings || { echo 'library build failed'; exit 1; }
+diff <(echo | GHC_NO_UNICODE="TRUE" cabal repl emit-warnings 2>&1) "$(dirname $0)/expected-warnings.txt" || { echo 'check failed'; exit 2; }
+1>&2 echo 'check passed'

--- a/ill-formedness-indicators/variadic-mkvec/test/expected-warnings.txt
+++ b/ill-formedness-indicators/variadic-mkvec/test/expected-warnings.txt
@@ -1,0 +1,128 @@
+Build profile: -w ghc-8.10.7 -O1
+In order, the following will be built (use -v for more details):
+ - variadic-mkvec-0.1.0.0 (test:emit-warnings) (ephemeral targets)
+Preprocessing test suite 'emit-warnings' for variadic-mkvec-0.1.0.0..
+GHCi, version 8.10.7: https://www.haskell.org/ghc/  :? for help
+[1 of 3] Compiling Test1            ( test/Test1.hs, interpreted )
+
+test/Test1.hs:19:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      enclosedGoodInferredSignature :: t1
+                                       -> t2 -> t3 -> Data.Vec.Vec '[t1, t2, t3]
+   |
+19 | enclosedGoodInferredSignature  a b c = X.variadic (X.litVec a b c)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:20:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      enclosedGoodInferredSignature1 :: Data.Vec.LiteralSyntax.EnclosedUnguarded.MkLitVec
+                                          '[t1, t2, t3]
+                                          (Data.Vec.LiteralSyntax.EnclosedOI.Variadic a) =>
+                                        t3 -> t2 -> t1 -> a
+   |
+20 | enclosedGoodInferredSignature1 a b c = XOI.variadic (XU.litVec a b c)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:21:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      enclosedGoodInferredSignature2 :: t1
+                                        -> t2 -> t3 -> Data.Vec.Vec '[t1, t2, t3]
+   |
+21 | enclosedGoodInferredSignature2 a b c = XU.variadic (XU.litVec a b c)
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:23:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      sentinelGoodInferredSignature :: t1
+                                       -> t2 -> t3 -> Data.Vec.Vec '[t1, t2, t3]
+   |
+23 | sentinelGoodInferredSignature  a b c = Y.beginVec a b c Y.endVec 
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:24:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      sentinelGoodInferredSignature' :: t1
+                                        -> t2 -> t3 -> Data.Vec.Vec '[t1, t2, t3]
+   |
+24 | sentinelGoodInferredSignature' a b c = YU.beginVec a b c YU.endVec 
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:32:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      enclosedBadInferredSignature :: Data.Vec.LiteralSyntax.EnclosedUnguarded.MkLitVec
+                                        '[t1, t2, t3] t4 =>
+                                      t3 -> t2 -> t1 -> t4
+   |
+32 | enclosedBadInferredSignature  a b c = XU.litVec a b c
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:33:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      enclosedBadInferredSignature' :: Data.Vec.LiteralSyntax.EnclosedOI.MkLitVec
+                                         '[t1, t2, t3] t4 =>
+                                       t3 -> t2 -> t1 -> t4
+   |
+33 | enclosedBadInferredSignature' a b c = XOI.litVec a b c
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+test/Test1.hs:35:1: warning: [-Wmissing-signatures]
+    Top-level binding with no type signature:
+      sentinelBadInferredSignature :: Data.Vec.LiteralSyntax.SentinelUnguarded.MkBeginVec
+                                        '[t1, t2, t3] t4 =>
+                                      t3 -> t2 -> t1 -> t4
+   |
+35 | sentinelBadInferredSignature a b c = YU.beginVec a b c
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+[2 of 3] Compiling Test2            ( test/Test2.hs, interpreted )
+
+test/Test2.hs:21:35: warning: [-Wdeferred-type-errors]
+    * Likely accidental use of `litVec' outside of `variadic'!
+    * In the expression: X.litVec a b c
+      In an equation for `enclosedGoodErrorMessage':
+          enclosedGoodErrorMessage a b c = X.litVec a b c
+   |
+21 | enclosedGoodErrorMessage  a b c = X.litVec a b c
+   |                                   ^^^^^^^^^^^^^^
+
+test/Test2.hs:22:35: warning: [-Wdeferred-type-errors]
+    * Likely accidental use of `litVec' outside of `variadic'!
+    * In the expression: XOI.litVec a b c
+      In an equation for enclosedGoodErrorMessage':
+          enclosedGoodErrorMessage' a b c = XOI.litVec a b c
+   |
+22 | enclosedGoodErrorMessage' a b c = XOI.litVec a b c
+   |                                   ^^^^^^^^^^^^^^^^
+
+test/Test2.hs:25:34: warning: [-Wdeferred-type-errors]
+    * Likely accidental use of `beginVec' without `endVec'!
+    * In the expression: Y.beginVec a b c
+      In an equation for `sentinelGoodErrorMessage':
+          sentinelGoodErrorMessage a b c = Y.beginVec a b c
+   |
+25 | sentinelGoodErrorMessage a b c = Y.beginVec a b c
+   |                                  ^^^^^^^^^^^^^^^^
+
+test/Test2.hs:32:33: warning: [-Wdeferred-type-errors]
+    * No instance for (Data.Vec.LiteralSyntax.EnclosedUnguarded.MkLitVec
+                         '[c, b, a] (Vec '[a, b, c]))
+        arising from a use of `XU.litVec'
+    * In the expression: XU.litVec a b c
+      In an equation for `enclosedBadErrorMessage':
+          enclosedBadErrorMessage a b c = XU.litVec a b c
+   |
+32 | enclosedBadErrorMessage a b c = XU.litVec a b c
+   |                                 ^^^^^^^^^^^^^^^
+
+test/Test2.hs:35:33: warning: [-Wdeferred-type-errors]
+    * No instance for (Data.Vec.LiteralSyntax.SentinelUnguarded.MkBeginVec
+                         '[c, b, a] (Vec '[a, b, c]))
+        arising from a use of `YU.beginVec'
+    * In the expression: YU.beginVec a b c
+      In an equation for `sentinelBadErrorMessage':
+          sentinelBadErrorMessage a b c = YU.beginVec a b c
+   |
+35 | sentinelBadErrorMessage a b c = YU.beginVec a b c
+   |                                 ^^^^^^^^^^^^^^^^^
+[3 of 3] Compiling Main             ( test/EmitWarnings.hs, interpreted )
+Ok, three modules loaded.
+*Main> *Main> Leaving GHCi.

--- a/ill-formedness-indicators/variadic-mkvec/variadic-mkvec.cabal
+++ b/ill-formedness-indicators/variadic-mkvec/variadic-mkvec.cabal
@@ -1,0 +1,52 @@
+cabal-version:      2.4
+name:               variadic-mkvec
+version:            0.1.0.0
+
+synopsis:           a variadic function for constructors vectors
+
+description:        a variadic function for constructors vectors without inscrutable error messages
+
+license:            BSD-2-Clause
+author:             Nicolas Frisby
+maintainer:         nicolas.frisby@gmail.com
+
+
+library
+    default-language: Haskell2010
+    build-depends:    base
+
+    hs-source-dirs:   src
+                       
+    exposed-modules:
+                      Data.Vec
+                      Data.Vec.LiteralSyntax.Enclosed
+                      Data.Vec.LiteralSyntax.EnclosedOI
+                      Data.Vec.LiteralSyntax.EnclosedUnguarded
+                      Data.Vec.LiteralSyntax.Sentinel
+                      Data.Vec.LiteralSyntax.SentinelUnguarded
+
+    ghc-options:
+                      -Wall
+                      -Wcompat
+                      -Wincomplete-uni-patterns
+                      -Wincomplete-record-updates
+                      -Wpartial-fields
+                      -Widentities
+                      -Wredundant-constraints
+                      -Wmissing-export-lists
+                      -Wno-unticked-promoted-constructors
+
+test-suite emit-warnings
+    default-language: Haskell2010
+    type:             exitcode-stdio-1.0
+
+    hs-source-dirs:   test
+
+    main-is:          EmitWarnings.hs
+    other-modules:
+                      Test1
+                      Test2
+
+    build-depends:
+                      base
+                    , variadic-mkvec


### PR DESCRIPTION
This PR adds the complete and self-contained Haskell code promised by the https://github.com/tweag/www/pull/1417 blog post.